### PR TITLE
Add missing functionality to CircutBreaker

### DIFF
--- a/CircuitBreaker/CircuitBreaker.sol
+++ b/CircuitBreaker/CircuitBreaker.sol
@@ -11,11 +11,11 @@ contract CircuitBreaker is Ownable {
     stopped = false;
   }
   function toggleActive() only_owner public {
+    stopped = !stopped;
   }
   
   modifier stop_if_emergency() {
-    
-    _;
+    if (!stopped){_;}
   }
   modifier emergency_only() {
     if (stopped) {_;}


### PR DESCRIPTION
The body for toggleActive() was missing, and stop_if_emergency would always run the modified function.